### PR TITLE
Fix on latest nightly by switching from std::simd to packed_simd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ categories = ["no-std", "hardware-support", "api-bindings"]
 repository = "https://github.com/AdamNiederer/vektor"
 readme = "README.org"
 edition = "2018"
+
+[dependencies]
+packed_simd = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 #![feature(stdsimd, attr_literals, rustc_attrs, crate_in_paths, tbm_target_feature, mmx_target_feature, sse4a_target_feature, aarch64_target_feature)]
 
+extern crate packed_simd as simd;
+
 //#![feature(aarch64_target_feature)]
 use core::mem;
-use core::simd;
 
 // Taken from stdsimd https://github.com/rust-lang-nursery/stdsimd/blob/3491956867a0873ecf7403d52cad6de3d9137b16/coresimd/x86/macros.rs
 macro_rules! constify_imm8 {


### PR DESCRIPTION
Fix on latest nightly by switching from `std::simd` to [`packed_simd`](https://github.com/rust-lang-nursery/packed_simd).

Fixes #2.