### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@ cargo-features = ["edition"]
 
 [package]
 name = "vektor"
-description = "Strongly typed explici SIMD"
+description = "Strongly typed explicit SIMD"
 authors = ["Adam Niederer <adam.niederer@gmail.com>"]
 license = "MPL-2.0"
 version = "0.2.2"
@@ -13,4 +13,4 @@ readme = "README.org"
 edition = "2018"
 
 [dependencies]
-packed_simd = {version = "0.3.4", package = "packed_simd_2"}
+packed_simd = "0.3.9"


### PR DESCRIPTION
packed_simd is now again being published under its original name.